### PR TITLE
Update NUMA Detection, Install OpenBLAS when required

### DIFF
--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -702,7 +702,7 @@ fi
 
 ubuntu=0
 if [ "`test_tools/detect_os`" == "ubuntu" ]; then
-  ubuntu=1
+	ubuntu=1
 fi
 
 # --regression and --mem_size are mutually exclusive, bail if both are set

--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -581,30 +581,39 @@ run_hpl()
 
 install_run_hpl()
 {
-	size_platform
-	check_mpi
-	clean_env
-	if [[ "$arch" == "x86_64" ]]; then
-		# Build AMD's special BLIS package
-		if [[ "$use_blis" == "1" ]]; then
-			echo "Using AMD BLIS"
-			blaslib="AMD_BLIS"
-			build_blis
-		elif [[ "$use_mkl" == "1" ]]; then
-			echo "Using Intel MKL"
-			blaslib="Intel_MKL"
-			install_mkl
-		else
-			echo "Using system OpenBLAS"
-			blaslib="${vendor}_openblas"
-		fi
-	elif [[ "$arch" == "aarch64" ]]; then
-		# Use OpenBLAS-openmp
-		echo "Using system OpenBLAS-OpenMP"
-		blaslib="aarch64_openblas"
-	fi
-	build_hpl 
-	run_hpl
+  size_platform
+  check_mpi
+  clean_env
+  if [[ "$arch" == "x86_64" ]]; then
+    # Build AMD's special BLIS package
+    if [[ "$use_blis" == "1" ]]; then
+      echo "Using AMD BLIS"
+      blaslib="AMD_BLIS"
+      build_blis
+    elif [[ "$use_mkl" == "1" ]]; then
+      echo "Using Intel MKL"
+      blaslib="Intel_MKL"
+      install_mkl
+    else
+      echo "Using system OpenBLAS"
+      blaslib="${vendor}_openblas"
+    fi
+  elif [[ "$arch" == "aarch64" ]]; then
+    # Use OpenBLAS-openmp
+    echo "Using system OpenBLAS-OpenMP"
+    blaslib="aarch64_openblas"
+  fi
+
+  if [ $blaslib == *"openblas" ]; then
+    pkgname="openblas-devel"
+    if [ $ubuntu -eq 1 ]; then  
+      pkgname="libopenblas-dev"
+    fi
+    test_tools/package_tool --packages $pkgname --no_install $to_no_install
+  fi
+
+  build_hpl 
+  run_hpl
 }
 
 use_mkl=0
@@ -691,10 +700,10 @@ if [ ${info} == "amzn2" ]; then
 	cp /usr/lib64/lib/libopenblas.so /usr/lib64/libopenblas.so
 	cp /usr/lib64/lib/libopenblas.so /usr/lib64/libopenblas.so.0
 fi
-info=`uname -a | cut -d' ' -f 4 | cut -d'-' -f2`
+
 ubuntu=0
-if [ ${info} == "Ubuntu" ]; then
-	ubuntu=1
+if [ "`test_tools/detect_os`" == "ubuntu" ]; then
+  ubuntu=1
 fi
 
 # --regression and --mem_size are mutually exclusive, bail if both are set

--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -193,7 +193,7 @@ size_platform()
 			MPI_PATH=/usr/lib64/openmpi/bin/
 		else
 			MPI_PATH=/usr/
-    		fi
+		fi
 	else
 		exit_out "Error: Architecture $arch is unsupported" 1
 	fi
@@ -278,7 +278,7 @@ size_platform()
 			# AMD Rome
 			NBS=224
 		elif [[ $family -eq 25 && $model -eq 1 ]]; then
-      			# AMD Milan
+			# AMD Milan
 			NBS=224
 		elif [[ $family -eq 25 && $model -eq 17 ]]; then
 			# AMD Genoa
@@ -580,39 +580,39 @@ run_hpl()
 
 install_run_hpl()
 {
-  size_platform
-  check_mpi
-  clean_env
-  if [[ "$arch" == "x86_64" ]]; then
-    # Build AMD's special BLIS package
-    if [[ "$use_blis" == "1" ]]; then
-      echo "Using AMD BLIS"
-      blaslib="AMD_BLIS"
-      build_blis
-    elif [[ "$use_mkl" == "1" ]]; then
-      echo "Using Intel MKL"
-      blaslib="Intel_MKL"
-      install_mkl
-    else
-      echo "Using system OpenBLAS"
-      blaslib="${vendor}_openblas"
-    fi
-  elif [[ "$arch" == "aarch64" ]]; then
-    # Use OpenBLAS-openmp
-    echo "Using system OpenBLAS-OpenMP"
-    blaslib="aarch64_openblas"
-  fi
+	size_platform
+	check_mpi
+	clean_env
+	if [[ "$arch" == "x86_64" ]]; then
+		# Build AMD's special BLIS package
+		if [[ "$use_blis" == "1" ]]; then
+			echo "Using AMD BLIS"
+			blaslib="AMD_BLIS"
+			build_blis
+		elif [[ "$use_mkl" == "1" ]]; then
+			echo "Using Intel MKL"
+			blaslib="Intel_MKL"
+			install_mkl
+		else
+			echo "Using system OpenBLAS"
+			blaslib="${vendor}_openblas"
+		fi
+	elif [[ "$arch" == "aarch64" ]]; then
+		# Use OpenBLAS-openmp
+		echo "Using system OpenBLAS-OpenMP"
+		blaslib="aarch64_openblas"
+	fi
 
-  if [[ $blaslib == *"openblas" ]]; then
-    pkgname="openblas-devel"
-    if [ $ubuntu -eq 1 ]; then  
-      pkgname="libopenblas-dev"
-    fi
-    test_tools/package_tool --packages $pkgname --no_install $to_no_install
-  fi
+	if [[ $blaslib == *"openblas" ]]; then
+		pkgname="openblas-devel"
+		if [ $ubuntu -eq 1 ]; then  
+			pkgname="libopenblas-dev"
+		fi
+		test_tools/package_tool --packages $pkgname --no_install $to_no_install
+	fi
 
-  build_hpl 
-  run_hpl
+	build_hpl 
+	run_hpl
 }
 
 use_mkl=0

--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -199,8 +199,7 @@ size_platform()
 	fi
 	model=$(grep "Model:" $LSCPU | cut -d: -f 2|sed -e s/^[[:space:]]*//g -e s/[[:space:]]*$//g)
 	stepping=$(grep "Stepping:" $LSCPU | cut -d: -f 2)
-	nodes=$(grep "NUMA node(s):" $LSCPU | cut -d: -f 2)
-	nodes=`echo $nodes | sed 's/^[[:space:]]*//g'`
+	nodes=`test_tools/detect_numa`
 	echo nodes $nodes
 	totcpus=$(grep "^CPU(s):" $LSCPU | cut -d: -f 2)
 	thpcore=$(grep "^Thread(s)" $LSCPU | cut -d: -f 2)

--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -604,7 +604,7 @@ install_run_hpl()
     blaslib="aarch64_openblas"
   fi
 
-  if [ $blaslib == *"openblas" ]; then
+  if [[ $blaslib == *"openblas" ]]; then
     pkgname="openblas-devel"
     if [ $ubuntu -eq 1 ]; then  
       pkgname="libopenblas-dev"


### PR DESCRIPTION
This PR updates NUMA detection to use `detect_numa` and install openblas when required.