### PR TITLE
Update build_run_hpl.sh

### DIFF
--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -283,9 +283,14 @@ size_platform()
 		elif [[ $family -eq 25 && $model -eq 17 ]]; then
 			# AMD Genoa
 			NBS=224
+   		elif [[ $family -eq 25 && $model -eq 160 ]]; then
+     			# AMD Bergamo
+			NBS=384
 		elif [[ $family -eq 6 ]]; then
 			# Intel
 			NBS=256
+   		else
+     			exit_out "Error: Arch ${arch} is supported, but family $family or model $model is not, exiting" 1
 		fi
 	elif [[ "$arch" == "aarch64" ]]; then
 		# Honestly this is just a guess, sadly


### PR DESCRIPTION
resolves #32 by adding an elif case for AMD Bergamo and an else case to report to the user when a x86_64 processor family or model is not yet supported.