### PR TITLE
Change --map-by socket to --map-by numa

### DIFF
--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -561,7 +561,7 @@ run_hpl()
 		if [[ -d /sys/devices/system/cpu/cpu0/cache/index3 ]]; then
 			bind_settings="--map-by l3cache"
 		else
-			bind_settings="--map-by socket"
+			bind_settings="--map-by numa"
 		fi
 		bind_settings="${bind_settings} -x OMP_NUM_THREADS=${NOMP}"
 		num_mpi=$NUM_MPI_PROCESS_MT


### PR DESCRIPTION
For systems that don't have an L3 descriptor I'd originally used --map-by socket to map MPI processes, thinking that would be roughly equivalent.  It turns out for KVM that's not correct because each core is also a socket; that would then map all the MPI process's OpenMP threads to exactly 1 core which is not at all what we want.  Fortunately --map-by numa looks to work properly.