### PR TITLE
Fix CPU family grep

### DIFF
--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -167,7 +167,7 @@ size_platform()
 		else
 			MPI_PATH=/usr/
 		fi
-		family=$(grep "CPU family" $LSCPU | cut -d: -f 2)
+		family=$(grep "^CPU family" $LSCPU | cut -d: -f 2)
 		#
 		# Strip off the weird marketing names
 		# Due to AWS being stupid on the naming, we need to


### PR DESCRIPTION
On some systems lscpu provides the field "BIOS CPU family" in addition to "CPU family", which breaks the wrapper's parsing and causes the script to abort. This change amends the parsing to only pick up on "CPU family" when it is the start of a new line.