### PR TITLE
When looking at the lscpu output,we are picking up extra fields.

### DIFF
--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -155,8 +155,8 @@ size_platform()
 {
 	LSCPU="$(mktemp /tmp/lscpu.XXXXXX)"
 	/usr/bin/lscpu > $LSCPU
-	arch=$(grep "Architecture:" $LSCPU | cut -d: -f 2|sed s/\ //g)
-	vendor=$(grep "Vendor ID:" $LSCPU | cut -d: -f 2|tr -cd '[:alnum:]' | sed -e s/^[[:space:]]*//g -e s/[[:space:]]*$//g)
+	arch=$(grep "^Architecture:" $LSCPU | cut -d: -f 2|sed s/\ //g)
+	vendor=$(grep "^Vendor ID:" $LSCPU | cut -d: -f 2|tr -cd '[:alnum:]' | sed -e s/^[[:space:]]*//g -e s/[[:space:]]*$//g)
 	if [[ "$arch" == "x86_64" ]]; then
 		BLAS_MT=1 #Set 1 to use Multi-thread BLAS, 0 for single thread
 


### PR DESCRIPTION
We are picking up on multiple fields with Vendor in it.  We want the field that starts with Vendor.  While we are making the change, do the same thing for Architecture.