### PR TITLE
Add test metrics to pcp.

### DIFF
--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -578,12 +578,12 @@ run_hpl()
 		#
 		if [[ $to_use_pcp -eq 1 ]]; then
 			start_pcp_subset
-			result2pcp iteration $i 
+			result2pcp iteration $i
 		fi
-		$MPI_PATH/bin/mpirun --allow-run-as-root -np $num_mpi --mca btl self,vader --report-bindings $bind_settings ./xhpl 2>&1 > hpl.out
-		cat hpl.out | grep -E "WC|WR"  >> $outfile
+		$MPI_PATH/bin/mpirun --allow-run-as-root -np $num_mpi --mca btl self,vader --report-bindings $bind_settings ./xhpl 2>&1 > auto_hpl.out
+		cat auto_hpl.out | grep -E "WC|WR"  >> $outfile
 		if [[ $to_use_pcp -eq 1 ]]; then
-			hpl_result_line=$(grep -E "WC|WR" hpl.out)
+			hpl_result_line=$(grep -E "WC|WR" auto_hpl.out)
 			if [[ -n "$hpl_result_line" ]]; then
 				read time_val gflops_val <<< $(echo "$hpl_result_line" | awk '{print $(NF-1), $NF}')
 				result2pcp hpl_time "$time_val"
@@ -598,6 +598,7 @@ run_hpl()
 		fi
 	done
 	cp $outfile $SCRIPT_DIR
+	cp auto_hpl.out $SCRIPT_DIR
 	cd $SCRIPT_DIR
 }
 
@@ -792,5 +793,5 @@ done
 cp $out_file results_auto_hpl.csv
 $TOOLS_BIN/validate_line --results_file results_auto_hpl.csv --base_results_file $run_dir/base_test_results/test1/verify
 rtc=$?
-$TOOLS_BIN/save_results --curdir $curdir --home_root $to_home_root --other_files "${curdir}/auto_hpl.out,*csv,test_results_report" --results $out_file  --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user $pdir
+$TOOLS_BIN/save_results --curdir $curdir --home_root $to_home_root --other_files "${SCRIPT_DIR}/auto_hpl.out,*csv,test_results_report" --results $out_file  --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user $pdir
 exit $rtc

--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -573,16 +573,29 @@ run_hpl()
 	echo "     T/V           N    NB     P     Q               Time                 Gflops"  >> $outfile
 	for i in $(seq "$NUM_ITER")
 	do
+		#
+		# start PCP subset
+		#
+		if [[ $to_use_pcp -eq 1 ]]; then
+			start_pcp_subset
+			result2pcp iteration $i 
+		fi
 		$MPI_PATH/bin/mpirun --allow-run-as-root -np $num_mpi --mca btl self,vader --report-bindings $bind_settings ./xhpl 2>&1 > hpl.out
 		cat hpl.out | grep -E "WC|WR"  >> $outfile
-	if [[ $to_use_pcp -eq 1 ]]; then
-		hpl_result_line=$(grep -E "WC|WR" hpl.out)
-		if [[ -n "$hpl_result_line" ]]; then
-			read time_val gflops_val <<< $(echo "$hpl_result_line" | awk '{print $(NF-1), $NF}')
- 			result2pcp hpl_time "$time_val"
- 			result2pcp hpl_gflops "$gflops_val"
+		if [[ $to_use_pcp -eq 1 ]]; then
+			hpl_result_line=$(grep -E "WC|WR" hpl.out)
+			if [[ -n "$hpl_result_line" ]]; then
+				read time_val gflops_val <<< $(echo "$hpl_result_line" | awk '{print $(NF-1), $NF}')
+				result2pcp hpl_time "$time_val"
+				result2pcp hpl_gflops "$gflops_val"
+			fi
 		fi
-	fi
+		#
+		# stop PCP subset
+		#
+		if [[ $to_use_pcp -eq 1 ]]; then
+			stop_pcp_subset
+		fi
 	done
 	cp $outfile $SCRIPT_DIR
 	cd $SCRIPT_DIR
@@ -737,21 +750,19 @@ ${curdir}/test_tools/gather_data ${curdir}
 #Setup and start PCP if --use_pcp is passed
 # using pdir 
 pdir=""
-if [[ $to_use_pcp -eq 1 ]]; then
-    source $TOOLS_BIN/pcp/pcp_commands.inc
-    setup_pcp
-    pcp_cfg=$TOOLS_BIN/pcp/default.cfg
-    pcpdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
-    pdir="--copy_dir $pcpdir"
-    echo "Start PCP"
-    start_pcp ${pcpdir}/ ${test_name} $pcp_cfg
-fi
 
 range=`seq 1 1 $to_times_to_run`
 for iteration in $range; do
-	#start PCP subset for iterations
 	if [[ $to_use_pcp -eq 1 ]]; then
-       	    start_pcp_subset
+		source $TOOLS_BIN/pcp/pcp_commands.inc
+		setup_pcp
+		pcp_cfg=$TOOLS_BIN/pcp/default.cfg
+		if [[ $pdir == "" ]]; then
+			pcpdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
+			pdir="--copy_dir $pcpdir"
+		fi
+		echo "Start PCP"
+		start_pcp ${pcpdir}/ ${test_name}_${iteration} $pcp_cfg
 	fi
 	install_run_hpl
 	pushd /tmp/results_auto_hpl_${to_tuned_setting} > /dev/null
@@ -768,22 +779,16 @@ for iteration in $range; do
 		$TOOLS_BIN/test_header_info --test_name ${test_name} --meta_output "$meta" --results_file $out_file
   		tail -n +2  $results | tr -s ' ' | sed "s/^ //g" | sed "s/ /:/g" >> $out_file
 	done
-	# stop PCP subset for iterations
-	if [[ $to_use_pcp -eq 1 ]]; then
-      	    echo "Send result to PCP archive for iteration $iteration"
-            stop_pcp_subset
-	fi
 	if [ $sleep_for -ne 0 ];then
 		if [ $iteration -ne $to_times_to_run ]; then
 			sleep $sleep_for
 		fi
 	fi
+	if [[ $to_use_pcp -eq 1 ]]; then
+		stop_pcp
+		shutdown_pcp
+	fi
 done
-if [[ $to_use_pcp -eq 1 ]]; then
-	echo "Stop PCP"
-	stop_pcp
-	shutdown_pcp
-fi
 cp $out_file results_auto_hpl.csv
 $TOOLS_BIN/validate_line --results_file results_auto_hpl.csv --base_results_file $run_dir/base_test_results/test1/verify
 rtc=$?

--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -578,7 +578,7 @@ run_hpl()
 		#
 		if [[ $to_use_pcp -eq 1 ]]; then
 			start_pcp_subset
-			result2pcp iteration $i
+			results2pcp_multiple "iteration:$i"
 		fi
 		$MPI_PATH/bin/mpirun --allow-run-as-root -np $num_mpi --mca btl self,vader --report-bindings $bind_settings ./xhpl 2>&1 > auto_hpl.out
 		cat auto_hpl.out | grep -E "WC|WR"  >> $outfile
@@ -586,8 +586,8 @@ run_hpl()
 			hpl_result_line=$(grep -E "WC|WR" auto_hpl.out)
 			if [[ -n "$hpl_result_line" ]]; then
 				read time_val gflops_val <<< $(echo "$hpl_result_line" | awk '{print $(NF-1), $NF}')
-				result2pcp hpl_time "$time_val"
-				result2pcp hpl_gflops "$gflops_val"
+				results2pcp_multiple "hpl_time:$time_val,hpl_gflops:$gflops_val"
+				reset_pcp_om
 			fi
 		fi
 		#

--- a/auto_hpl/openmetrics_auto_hpl_reset.txt
+++ b/auto_hpl/openmetrics_auto_hpl_reset.txt
@@ -1,0 +1,9 @@
+iteration 0
+running 0
+numthreads 0
+runtime NaN
+throughput NaN
+latency NaN
+hpl_time NaN
+hpl_gflops NaN
+

--- a/auto_hpl/openmetrics_auto_hpl_reset.txt
+++ b/auto_hpl/openmetrics_auto_hpl_reset.txt
@@ -6,4 +6,3 @@ throughput NaN
 latency NaN
 hpl_time NaN
 hpl_gflops NaN
-


### PR DESCRIPTION
# Description
1) Adds the open metric file for the test metrics itself.
2) Handles iterations better.

# Before/After Comparison
Before
Logging results hpl_time 261.59
Unexpected metric logged. Check for a typo.
Logging results hpl_gflops 1.3036e+02
Unexpected metric logged. Check for a typo.
Send result to PCP archive for iteration 1
Stopping PCP subset
Stop PCP
Ran

pcp output
         o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.hpl_time  o.w.hpl_gflops
16:24:22          1.000        1.000           0.000          NaN             NaN          NaN       295.870         127.590
16:24:23          1.000        1.000           0.000          NaN             NaN          NaN       295.870         127.590

         
For cases where the --iteration <n> is passed into the test, there will be 1 set pcp data for each iteration.                                                                                                                         

# Clerical Stuff
This closes #58

Relates to JIRA: RPOPC-759

# Test results

=======================
csv file
=======================
 T/V:N:NB:P:Q:Time:Gflops
WR12R2R4:38400:256:1:1:295.87:1.2759e+02


====================================
pcp snippet
====================================
pcp output
         o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.hpl_time  o.w.hpl_gflops
16:24:22          1.000        1.000           0.000          NaN             NaN          NaN       295.870         127.590
16:24:23          1.000        1.000           0.000          NaN             NaN          NaN       295.870         127.590


-x output
[auto_x.txt](https://github.com/user-attachments/files/24742418/auto_x.txt)


================================================================================
