### PR TITLE
Add more specific error return codes

### DIFF
--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -111,7 +111,7 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit_out "Error: pulling git $tools_git failed." 1
+                        exit_out "Error: pulling git $tools_git failed." 101
                 fi
         fi
 }

--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -94,7 +94,7 @@ attempt_tools_wget()
         fi
 }
 
-attetmpt_tools_curl()
+attempt_tools_curl()
 {
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 curl -L -O ${tools_git}/archive/refs/heads/main.zip
@@ -117,7 +117,7 @@ attempt_tools_git()
 }
 
 attempt_tools_wget
-attetmpt_tools_curl
+attempt_tools_curl
 attempt_tools_git
 
 usage()

--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -81,13 +81,44 @@ sleep_for=0
 #
 TOOLS_BIN=${HOME}/test_tools
 export TOOLS_BIN
-if [ ! -d "${TOOLS_BIN}" ]; then
-	git clone $tools_git ${TOOLS_BIN}
-	if [ $? -ne 0 ]; then
-		exit_out "pulling git $tools_git failed." $E_GENERAL
-	fi
-fi
 
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attetmpt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 1
+                fi
+        fi
+}
+
+attempt_tools_wget
+attetmpt_tools_curl
+attempt_tools_git
 
 usage()
 {

--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -129,7 +129,7 @@ usage()
 	echo "  --use_blis: use the blis lib."
 	echo "  --regression: limit the amount of memory for regression."
 	source ${TOOLS_BIN}/general_setup --usage
-	exit 0
+	exit $E_USAGE
 }
 
 found=0

--- a/auto_hpl/generate_makefile.sh
+++ b/auto_hpl/generate_makefile.sh
@@ -15,7 +15,7 @@ usage() {
     echo "  --mpi-inc    : MPI include path (e.g., /usr/include/openmpi-x86_64)"
     echo "  --output     : Output makefile path"
     echo "  --blas-dir   : Optional BLAS library directory (for BLIS custom builds)"
-    exit 1
+    exit $E_USAGE
 }
 
 # Parse arguments
@@ -61,7 +61,7 @@ fi
 
 if [ ! -f "$TEMPLATE" ]; then
     echo "Error: Template file '$TEMPLATE' not found"
-    exit 1
+    exit $E_GENERAL
 fi
 
 # Generate makefile from template
@@ -153,8 +153,8 @@ fi
 
 if [ $? -eq 0 ]; then
     echo "Makefile generated successfully: $OUTPUT"
-    exit 0
+    exit $E_SUCCESS
 else
     echo "Error: Failed to generate makefile"
-    exit 1
+    exit $E_GENERAL
 fi


### PR DESCRIPTION
# Description
Uses error_codes found in test_tools/error_codes to provide more specific error indication.

# Before/After Comparison
Before: Returned a 0 or 1, making determination of having to rerun very course
After: Error codes are now bases on test_tools/error_codes, making it easier to limit when we do a rerun of the test.
Also, changed how we load in test_tools, we try curl, git, and wget, to avoid a failure due to the program not
being installed.

# Clerical Stuff
This closes #65 

Relates to JIRA: RPOPC-870

Testing Done
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: documentation
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "auto_hpl"
    host_config: "m5.xlarge"

csv results
TV,N,NB,P,Q,Time,Gflops,Start_Date,End_Date
WR12R2R4,38400,256,1,1,296.11,1.2749e+02,2026-03-13T14:45:23Z,2026-03-13T14:51:20Z

Returned 0 as expected. Testing on rerun verification handled in the appropriate zathras pr.

