### PR TITLE
Make NBS logic less fragile

### DIFF
--- a/auto_hpl/build_run_hpl.sh
+++ b/auto_hpl/build_run_hpl.sh
@@ -292,21 +292,16 @@ size_platform()
 		NS=$((NS / 4))
 	fi
 	if [[ "$arch" == "x86_64" ]]; then
-		if [[ $family -eq 23 && $model -eq 1 ]]; then
-			# AMD Naples
-			NBS=232
-		elif [[ $family -eq 23 && $model -eq  49 ]]; then
-			# AMD Rome
+		if [[ $family -eq 23 || $family -eq 25 || $family -eq 26 ]]; then
+			# AMD defaults to 224, but there are overrides for some platforms
 			NBS=224
-		elif [[ $family -eq 25 && $model -eq 1 ]]; then
-			# AMD Milan
-			NBS=224
-		elif [[ $family -eq 25 && $model -eq 17 ]]; then
-			# AMD Genoa
-			NBS=224
-   		elif [[ $family -eq 25 && $model -eq 160 ]]; then
-     			# AMD Bergamo
-			NBS=384
+			if [[ $family -eq 23 && $model -eq 1 ]]; then
+				# AMD Naples
+				NBS=232
+			elif [[ $family -eq 25 && $model -eq 160 ]]; then
+				# AMD Bergamo
+				NBS=384
+			fi
 		elif [[ $family -eq 6 ]]; then
 			# Intel
 			NBS=256


### PR DESCRIPTION
# Description
Fix the NBS logic so we don't keep failing every time AMD comes out with a new CPU.  Instead of special casing every family+model for AMD, use a default that has been consistent over the years and only special case those where something else has been found to be better.

# Before/After Comparison
Before:
Most recently, on Turin we'd see this error and then exit:
Error: Arch x86_64 is supported, but family 26 or model 2 is not, exiting

After:
We use the default NBS setting of 224 and the benchmark runs to completion.

```
[root@perf-amd-12 auto_hpl]# cat hpl-AMD_openblas-2026.05.14-09.23.34.log 
/usr/lib64/openmpi/bin/mpirun --allow-run-as-root -np 32 --mca btl self,vader --report-bindings --map-by l3cache -x OMP_NUM_THREADS=8 ./xhpl
     TV           N    NB     P     Q               Time                 Gflops
WR12R2R4      273504   224     4     8             998.41             1.3661e+04
```

# Clerical Stuff
This closes #69 
Relates to JIRA: RPOPC-1050
